### PR TITLE
Fix the rollDice example returning 0 as value

### DIFF
--- a/examples/roll-dice-project/plugins/roll-dice/build.sh
+++ b/examples/roll-dice-project/plugins/roll-dice/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+docker run --rm \
+    -v ${SCRIPT_DIR}/:/src \
+    -w /src tinygo/tinygo:0.37.0 bash \
+    -c "tinygo build -scheduler=none --no-debug -target=wasi -o /tmp/tmp.wasm main.go && cat /tmp/tmp.wasm" > \
+    ${SCRIPT_DIR}/main.wasm

--- a/examples/roll-dice-project/plugins/roll-dice/main.go
+++ b/examples/roll-dice-project/plugins/roll-dice/main.go
@@ -17,7 +17,7 @@ type Arguments struct {
 // and returns the sum of the results
 
 //export rollDice
-func rollDice() {
+func rollDice() int32 {
 
 	arguments := pdk.InputString()
 
@@ -37,7 +37,7 @@ func rollDice() {
 	}
 	
 	pdk.OutputString(strconv.Itoa(sum))
-	
+	return 0
 }
 
 func main() {


### PR DESCRIPTION
According to the documentation: https://github.com/extism/go-pdk?tab=readme-ov-file#getting-started

> 3. An Extism export expects an i32 return code. 0 is success and 1 is a failure.

I took the freedom to add a simple build script useful to test things out.